### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,11 @@ cmsplugin-articles
 .. |ci| image:: https://travis-ci.org/satyrius/cmsplugin-articles.png?branch=master
     :target: https://travis-ci.org/satyrius/cmsplugin-articles
 
-.. |pypi| image:: https://pypip.in/version/cmsplugin-articles/badge.png?text=pypi
+.. |pypi| image:: https://img.shields.io/pypi/v/cmsplugin-articles.svg?label=pypi
     :target: https://pypi.python.org/pypi/cmsplugin-articles/
     :alt: Latest Version
 
-.. |status| image:: https://pypip.in/status/cmsplugin-articles/badge.png
+.. |status| image:: https://img.shields.io/pypi/status/cmsplugin-articles.svg
     :target: https://pypi.python.org/pypi/cmsplugin-articles/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cmsplugin-articles))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cmsplugin-articles`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.